### PR TITLE
test: add `chrome` object to `globals`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,11 @@ module.exports = {
   transform: {
     "^.+\\.(t|j)sx?$": ["@swc/jest"],
   },
+  globals: {
+    chrome: {
+      i18n: {
+        getMessage: (key) => key,
+      },
+    },
+  },
 }


### PR DESCRIPTION
Resolved a problem with the `chrome` object causing a reference error when running the test suite with Jest.

```
❯ npx jest      
 FAIL  src/methods/ReportTemplateGenerator.test.ts
  ● Test suite failed to run

    ReferenceError: chrome is not defined

      111 | \\begin{document}
      112 | \\title{{{course-name}}\\\\{{report-title}}}
    > 113 | \\author{{{student-name}}\\\\${chrome.i18n.getMessage(
          |                                ^
      114 |     "report_template_student_code"
      115 |   )}}
      116 | \\lstset{

      at Object.chrome (src/methods/ReportTemplateGenerator.tsx:113:32)
      at Object.<anonymous> (src/methods/ReportTemplateGenerator.test.ts:5:34)

```